### PR TITLE
Application support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,10 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- Added ability to specify a module name for ordinary (non-BEAM) files (API-only).
+- Added support for tracking dependencies using application spec files as binaries
+(API-only)
+- Added PropEr test
+
+### Fixed
+- Fixed a bug in parsing non-BEAM files in included AVM files, which would cause
+  non-BEAM file contents to be loaded incorrectly.
+
 ## [0.4.1]
 
-- Fixed a bug that failed to track atoms that occur in BEAM LitT tables
+### Added
 - Added unit tests
+
+### Fixed
+- Fixed a bug that failed to track atoms that occur in BEAM LitT tables
+
+### Changed
 - Weakened the test for finding a start BEAM file such that it only requires that the `?BEAM_START_FLAG` be set, for compatibility with [ExAtomVM](https://github.com/atomvm/ExAtomVM).
 
 ## [0.4.0]

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,10 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for tracking dependencies using application spec files as binaries
 (API-only)
 - Added PropEr test
+- Added new `format` option to the `list` subcommand, supporting `csv`, `bare`,
+and `default` options.
 
 ### Fixed
 - Fixed a bug in parsing non-BEAM files in included AVM files, which would cause
   non-BEAM file contents to be loaded incorrectly.
+
+### Changed
+- Changed the command line syntax to support long and short option names using
+GNU-style conventions; deprecated single-hyphen short options.
+- Moved `packbeam` API functionality into `packbeam_api` module.
+Previous `packbeam` API functions now call corresponding `packbeam_api`
+functions and are deprecated.
 
 ## [0.4.1]
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ## All rights reserved.
 ##
 
-all: compile escript edoc
+all: compile escript edoc etest
 
 compile:
 	rebar3 compile
@@ -16,4 +16,11 @@ edoc:
 
 etest:
 	rebar3 eunit --cover
+	rebar3 proper --cover
 	rebar3 cover --verbose
+
+clean:
+	rm -rf _build
+
+publish:
+	rebar3 hex publish

--- a/README.md
+++ b/README.md
@@ -29,26 +29,43 @@ These commands will create an Erlang `escript` file called `packbeam` under
 
 in your local working directory.
 
-> TODO release
-
 # `packbeam` command
 
-The `packbeam` command is used to create an AVM file from a list of beam and other file types, or to list the contents of an AVM file.
+The `packbeam` command is used to create an AVM file from a list of beam and other file types, to list the contents of an AVM file, or to delete elements from an AVM file.
 
-The general syntax of the `packbeam` command takes the form
+The general syntax of the `packbeam` command takes the form:
 
-    shell$ packbeam <sub-command> <args>
+    packbeam <sub-command> <args>
 
 On-line help is available via the `help` sub-command:
 
     shell$ packbeam help
     Syntax:
-        packbeam <sub-command> <options>
+    packbeam <sub-command> <options> <args>
 
     The following sub-commands are supported:
-        create [-prune] [-start <module>] <output-avm-file> [<input-file>]+
-        list <input-avm-file-path>
-        delete [-out <output-avm-file-path>] <input-avm-file-path> [<name>]+
+
+        create <options> <output-avm-file> [<input-file>]+
+            where:
+            <output-avm-file> is the output AVM file,
+            [<input-file>]+ is is a list of one or more input files,
+            and <options> are among the following:
+                [--prune|-p]           Prune dependencies
+                [--start|-s <module>]  Start module
+
+        list <options> <avm-file>
+            where:
+            <avm-file> is an AVM file,
+            and <options> are among the following:
+                [--format|-f csv|bare|default]  Format output
+
+        delete <options> <avm-file> [<element>]+
+            where:
+            <avm-file> is an AVM file,
+            [<element>]+ is is a list of one or more elements to delete,
+            and <options> are among the following:
+                [-out <output-avm-file>]    Output AVM file
+
         help  print this help
 
 The `packbeam` command will return an exit status of 0 on successful completion of a command.  An unspecified non-zero value is returned in the event of an error.
@@ -63,13 +80,21 @@ To create an AVM file from a list of beam files, use the `create` sub-command to
 
 This command will create an AtomVM AVM file suitable for use with AtomVM.
 
-> Note that any beam files specified are stripped of their path information, inside of the generated AVM file.  Any files that have the same name will be added in the order they are listed on the command line.  However, AtomVM will only resolve the first such file when loading modules at run-time.
+The input files specified in the create subcommand may be among the following types:
 
-If you are building an application (as opposed to a library, suitable for inclusion in another AVM file), then at least one beam module in an AVM file should contain a `start/0` entry-point, i.e., a function called `start` with arity 0.  AtomVM will use this entry-point as the first function to execute, when starting.
+* compiled BEAM files (typically ending in `.beam`)
+* Previously created AVM files
+* "Normal" files, e.g., text files, binary files, etc.
+
+Note that beam files specified are stripped of their path information, inside of the generated AVM file.  Any files that have the same name will be added in the order they are listed on the command line.  However, AtomVM will only resolve the first such file when loading modules at run-time.
+
+### Start Entrypoint
+
+If you are building an application that provides a start entrypoint (as opposed to a library, suitable for inclusion in another AVM file), then at least one beam module in an AVM file must contain a `start/0` entry-point, i.e., a function called `start` with arity 0.  AtomVM will use this entry-point as the first function to execute, when starting.
 
 > Note.  It is conventional, but not required, that the first beam file in an AVM file contains the `start/0` entry-point.  AtomVM will use the first BEAM file that contains an exported `start/0` function as the entry-point for the application.
 
-If your application has multiple modules with exported `start/0` functions, you may use the `-start <module>` option to specify the module you would like placed first in your AVM file.  The `<module>` parameter should be the module name (without the `.beam` suffix, e.g., `main`).
+If your application has multiple modules with exported `start/0` functions, you may use the `--start <module>`  (alternatively, `-s <module>`) option to specify the module you would like placed first in your AVM file.  The `<module>` parameter should be the module name (without the `.beam` suffix, e.g., `main`).
 
 A previously created AVM file file may be supplied as input (including the same file specified as output, for example).  The contents of any input AVM files will be included in the output AVM file.  For example, if you are building a library of BEAM files (for example, none of which contain a `start/0` entry-point), you may want to archive these into an AVM file, which can be used for downstream applications.
 
@@ -79,21 +104,32 @@ In addition, you may specify a "normal" (i.e., non-beam or non-AVM) file.  Norma
 
 > Note.  It is conventional in AtomVM for normal files to have the path `<module-name>/priv/<file-name>`.
 
-If you specify the `-prune` flag, then `packbeam` will only include beam files that are transitively dependent on the entry-point beam.  Transitive dependencies are determined by imports, as well as use of an atom in a module (e.g, as the result of a dynamic function call, based on a module name).
+### Pruning
 
-If there is no beam file with a `start/0` entry-point defined in the list of input modules and the `-prune` flag is used, the command will fail.  You should _not_ use the `-prune` flag if you are trying to build libraries suitable for inclusion on other AtomVM applications.
+If you specify the `--prune` (alternatively, `-p`) flag, then `packbeam` will only include beam files that are transitively dependent on the entry-point beam.  Transitive dependencies are determined by imports, as well as use of an atom in a module (e.g, as the result of a dynamic function call, based on a module name).
+
+If there is no beam file with a `start/0` entry-point defined in the list of input modules and the `--prune` flag is used, the command will fail.  You should _not_ use the `--prune` flag if you are trying to build libraries suitable for inclusion on other AtomVM applications.
 
 ## `list` sub-command
 
-The `list` sub-command will print the contents of an AVM file to the standard output stream.  If a beam file contain an exported `start/0` function, it will be marked with an asterisk (`*`).  The size in bytes of each module is also printed in square brackets (`[]`).
+The `list` sub-command will print the contents of an AVM file to the standard output stream.
 
-To list the contents of an AVM file, specify the location of the AVM file to input as the first argument:
+To list the elements of an AVM file, specify the location of the AVM file to input as the first argument:
 
     shell$ packbeam list mylib.avm
     mylib.beam * [284]
     foo.beam [276]
     bar.beam [252]
     mylib/priv/sample.txt [29]
+
+The elements in the AVM file are printed to the standard output stream and are listed on each line.  If a beam file contain an exported `start/0` function, it will be marked with an asterisk (`*`).  The size in bytes of each module is also printed in square brackets (`[]`).
+
+You may use the `--format` (alternatively, `-f`) option to specify an output format.  The supported formats are:
+
+* `csv`  Output elements in comma-separated value format.  Fields include the module name, whether the element is a BEAM file, whether the element provides a `start/0` entrypoint, and the size (in bytes) of the element.
+* `bare`  Output just the module name, with no annotations.
+* `default`  Output the module name, size (in brackets), and whether the file provides a `start/0` entrypoint, indicated by an asterisk (`*`).  The `default` output is used if the `--format` option is not specified.
+
 
 ## `delete` sub-command
 
@@ -108,6 +144,6 @@ For example:
     mylib.beam * [284]
     mylib/priv/sample.txt [29]
 
-# `packbeam` API
+# `packbeam_api` API
 
 > TODO Used by rebar plugin

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,15 @@
     {main, <<"readme">>}
 ]}.
 {hex, [{doc, edoc}]}.
-{plugins, [rebar3_hex]}.
+{plugins, [rebar3_hex, rebar3_proper]}.
 
 %% Profiles
-{profiles, [{test, [{erl_opts, [debug_info]},{cover_enabled, true}]}]}.
+{profiles, [
+    {test, [
+        {erl_opts, [debug_info]},
+        {cover_enabled, true},
+        {deps, [
+            {proper, "1.4.0"}
+        ]}
+    ]}
+]}.

--- a/src/packbeam.app.src
+++ b/src/packbeam.app.src
@@ -24,7 +24,7 @@
         {registered, []},
         {applications, [kernel, stdlib]},
         {env, []},
-        {modules, [packbeam]},
+        {modules, [packbeam_api]},
         {licenses, ["Apache 2.0"]},
         {pkg_name, "atomvm_packbeam"},
         {links, [{"github", "https://github.com/atomvm/atomvm_packbeam"}]}

--- a/src/packbeam.erl
+++ b/src/packbeam.erl
@@ -23,603 +23,46 @@
 %%-----------------------------------------------------------------------------
 -module(packbeam).
 
-%% API exports
--export([create/2, create/4, create/5, list/1, delete/3]).
+%% API exports (for backwards compatibility)
+-export([create/2, create/4, list/1, delete/3]).
 %% escript
 -export([main/1]).
-
--define(AVM_HEADER,
-    16#23, 16#21, 16#2f, 16#75,
-    16#73, 16#72, 16#2f, 16#62,
-    16#69, 16#6e, 16#2f, 16#65,
-    16#6e, 16#76, 16#20, 16#41,
-    16#74, 16#6f, 16#6d, 16#56,
-    16#4d, 16#0a, 16#00, 16#00
-).
--define(ALLOWED_CHUNKS, [
-    "AtU8", "Code", "ExpT", "LocT", "ImpT", "LitU", "FunT", "StrT", "LitT"
-]).
--define(BEAM_START_FLAG, 1).
--define(BEAM_CODE_FLAG, 2).
--define(NORMAL_FILE_FLAG, 4).
-
--type path() :: string().
--type parsed_file() :: [{string(), term()}].
 
 %%
 %% Public API
 %%
 
 %%-----------------------------------------------------------------------------
-%% @param   OutputPath the path to write the AVM file
-%% @param   InputPaths a list of paths of beam files, AVM files, or normal data files
-%% @returns ok if the file was created.
-%% @throws  Reason::string()
-%% @doc     Create an AVM file.
-%%
-%%          Equivalent to create(OutputPath, InputPaths, false).
+%% @doc     Deprecated.  Use the packbeam_api module, instead.
 %% @end
 %%-----------------------------------------------------------------------------
--spec create(path(), [path()]) -> ok | {error, Reason :: term()}.
 create(OutputPath, InputPaths) ->
-    create(OutputPath, InputPaths, undefined, false, undefined).
+    io:format("WARNING.  packbeam:create/2 is deprecated.  Use packbeam_api::create/2 instead.~n"),
+    packbeam_api:create(OutputPath, InputPaths).
 
 %%-----------------------------------------------------------------------------
-%% @param   OutputPath the path to write the AVM file
-%% @param   InputPaths a list of paths of beam files, AVM files, or normal data files
-%% @returns ok if the file was created.
-%% @throws  Reason::string()
-%% @doc     Create an AVM file.
-%%
-%%          Equivalent to create(OutputPath, InputPaths, undefined, Prune, StartModule).
+%% @doc     Deprecated.  Use the packbeam_api module, instead.
 %% @end
 %%-----------------------------------------------------------------------------
--spec create(path(), [path()], Prune :: boolean(), StartModule :: module() | undefined) ->
-    ok | {error, Reason :: term()}.
 create(OutputPath, InputPaths, Prune, StartModule) ->
-    create(OutputPath, InputPaths, undefined, Prune, StartModule).
+    io:format("WARNING.  packbeam:create/4 is deprecated.  Use packbeam_api::create/4 instead.~n"),
+    packbeam_api:create(OutputPath, InputPaths, Prune, StartModule).
 
 %%-----------------------------------------------------------------------------
-%% @param   OutputPath the path to write the AVM file
-%% @param   InputPaths a list of paths of beam files, AVM files, or normal data files
-%% @param   Prune whether to prune the archive.  Without pruning, all found BEAM files are included
-%%          in the output AVM file.  With pruning, then packbeam will attempt to
-%%          determine which BEAM files are needed to run the application, depending
-%%          on which modules are (transitively) referenced from the AVM entrypoint.
-%% @returns ok if the file was created.
-%% @throws  Reason::string()
-%% @doc     Create an AVM file.
-%%
-%%          This function will create an AVM file at the location specified in
-%%          OutputPath, using the input files specified in InputPaths.
+%% @doc     Deprecated.  Use the packbeam_api module, instead.
 %% @end
 %%-----------------------------------------------------------------------------
--spec create(path(), [path()], module() | undefined, Prune :: boolean(), StartModule :: module() | undefined) ->
-    ok | {error, Reason :: term()}.
-create(OutputPath, InputPaths, ApplicationModule, Prune, StartModule) ->
-    ParsedFiles = parse_files(InputPaths, StartModule),
-    write_packbeam(
-        OutputPath,
-        case Prune of
-            true -> prune(ParsedFiles, ApplicationModule);
-            _ -> ParsedFiles
-        end
-    ).
-
-%%-----------------------------------------------------------------------------
-%% @param   InputPath the AVM file from which to list elements
-%% @returns list of parsed file data
-%% @throws  Reason::string()
-%% @doc     List the contents of an AVM file.
-%%
-%%          This function will list the contents of an AVM file at the
-%%          location specified in InputPath.
-%% @end
-%%-----------------------------------------------------------------------------
--spec list(path()) -> [parsed_file()].
 list(InputPath) ->
-    case file_type(InputPath) of
-        avm ->
-            parse_file(InputPath);
-        _ ->
-            throw(io_lib:format("Expected AVM file: ~p", [InputPath]))
-    end.
+    io:format("WARNING.  packbeam:list/1 is deprecated.  Use packbeam_api::list/1 instead.~n"),
+    packbeam_api:list(InputPath).
 
 %%-----------------------------------------------------------------------------
-%% @param   InputPath the AVM file from which to delete elements
-%% @param   OutputPath the path to write the AVM file
-%% @param   Names a list of elements from the source AVM file to delete
-%% @returns ok if the file was created.
-%% @throws  Reason::string()
-%% @doc     Delete selected elements of an AVM file.
-%%
-%%          This function will delete elements of an AVM file at the location specified in
-%%          InputPath, specified by the supplied list of names.  The output AVM file
-%%          is written to OutputPath, which may be the same as InputPath.
+%% @doc     Deprecated.  Use the packbeam_api module, instead.
 %% @end
 %%-----------------------------------------------------------------------------
--spec delete(path(), path(), [path()]) -> ok | {error, Reason :: term()}.
 delete(OutputPath, InputPath, Names) ->
-    case file_type(InputPath) of
-        avm ->
-            ParsedFiles = parse_file(InputPath),
-            write_packbeam(OutputPath, remove_names(Names, ParsedFiles));
-        _ ->
-            throw(io_lib:format("Expected AVM file: ~p", [InputPath]))
-    end.
-
-%%
-%% Internal API functions
-%%
-
-%% @private
-parse_files(InputPaths, StartModule) ->
-    Files = lists:foldl(
-        fun(InputPath, Accum) ->
-            Accum ++ parse_file(InputPath)
-        end,
-        [],
-        InputPaths
-    ),
-    case StartModule of
-        undefined ->
-            Files;
-        _ ->
-            reorder_start_module(StartModule, Files)
-    end.
-
-%% @private
-parse_file({InputPath, ModuleName}) ->
-    parse_file(file_type(InputPath), ModuleName, load_file(InputPath));
-parse_file(InputPath) ->
-    parse_file(file_type(InputPath), InputPath, load_file(InputPath)).
-
-%% @private
-file_type(InputPath) ->
-    case ends_with(InputPath, ".beam") of
-        true ->
-            beam;
-        _ ->
-            case ends_with(InputPath, ".avm") of
-                true -> avm;
-                _ -> normal
-            end
-    end.
-
-%% @private
-load_file(Path) ->
-    case file:read_file(Path) of
-        {ok, Data} ->
-            Data;
-        {error, Reason} ->
-            throw(io_lib:format("Unable to load file ~s.  Reason: ~p", [Path, Reason]))
-    end.
-
-%% @private
-prune(ParsedFiles, RootApplicationModule) ->
-    case find_entrypoint(ParsedFiles) of
-        false ->
-            throw("No input beam files contain start/0 entrypoint");
-        {value, Entrypoint} ->
-            BeamFiles = lists:filter(fun is_beam/1, ParsedFiles),
-            Modules = closure(Entrypoint, BeamFiles, [get_module(Entrypoint)]),
-            ApplicationStartModules = find_application_modules(ParsedFiles, RootApplicationModule),
-            ApplicationModules = find_dependencies(ApplicationStartModules, BeamFiles),
-            filter_modules(Modules ++ ApplicationModules, ParsedFiles)
-    end.
-
-find_application_modules(_ParsedFiles, undefined) ->
-    [];
-find_application_modules(ParsedFiles, ApplicationModule) ->
-    ApplicationSpecs = find_all_application_specs(ParsedFiles),
-    find_application_start_modules(ParsedFiles, ApplicationSpecs, ApplicationModule).
-
-find_all_application_specs(ParsedFiles) ->
-    ApplicationFiles = lists:filter(
-        fun is_application_file/1,
-        ParsedFiles
-    ),
-    [get_application_spec(ApplicationFile) || ApplicationFile <- ApplicationFiles].
-
-find_application_start_modules(ParsedFiles, ApplicationSpecs, ApplicationModule) ->
-    case find_application_spec(ApplicationSpecs, ApplicationModule) of
-        false ->
-            [];
-        {value, {application, _ApplicationModule, Properties}} ->
-            ChildApplicationStartModules = case proplists:get_value(applications, Properties) of
-                Applications when is_list(Applications) ->
-                    lists:foldl(
-                        fun(Application, InnerAccum) ->
-                            find_application_start_modules(ParsedFiles, ApplicationSpecs, Application) ++ InnerAccum
-                        end,
-                        [],
-                        Applications
-                    );
-                _ ->
-                    []
-            end,
-            StartModules = case proplists:get_value(mod, Properties) of
-                {StartModule, _Args} when is_atom(StartModule) ->
-                    [StartModule];
-                _ ->
-                    []
-            end,
-            ChildApplicationStartModules ++ StartModules
-    end.
-
-find_dependencies(Entrypoints, BeamFiles) ->
-    deduplicate(
-        lists:flatten(
-            [
-                closure(
-                    get_parsed_file(Entrypoint, BeamFiles),
-                    BeamFiles,
-                    [Entrypoint]
-                ) || Entrypoint <- Entrypoints
-            ]
-        )
-    ).
-
-find_application_spec(ApplicationSpecs, ApplicationModule) ->
-    lists:search(
-        fun({application, Module, _Properties}) ->
-            Module =:= ApplicationModule
-        end,
-        ApplicationSpecs
-    ).
-
-get_application_spec(ApplicationFile) ->
-    ApplicationData = get_data(ApplicationFile),
-    <<_Size:4/binary, SerializedTerm/binary>> = ApplicationData,
-    binary_to_term(SerializedTerm).
-
-is_application_file(ParsedFile) ->
-    case not is_beam(ParsedFile) of
-        true ->
-            ModuleName = get_module_name(ParsedFile),
-            Components = string:split(ModuleName, "/", all),
-            case Components of
-                [_ModuleName, "priv", "application.bin"] ->
-                    true;
-                _ ->
-                    false
-            end;
-        false ->
-            false
-    end.
-
-%% @private
-find_entrypoint(ParsedFiles) ->
-    lists:search(fun is_entrypoint/1, ParsedFiles).
-
-%% @private
-is_entrypoint(Flags) when is_integer(Flags) ->
-    Flags band ?BEAM_START_FLAG =:= ?BEAM_START_FLAG;
-is_entrypoint(ParsedFile) ->
-    is_entrypoint(proplists:get_value(flags, ParsedFile)).
-
-%% @private
-is_beam(Flags) when is_integer(Flags) ->
-    Flags band ?BEAM_CODE_FLAG =:= ?BEAM_CODE_FLAG;
-is_beam(ParsedFile) ->
-    is_beam(proplists:get_value(flags, ParsedFile)).
-
-%% @private
-closure(_Current, [], Accum) ->
-    lists:reverse(Accum);
-closure(Current, Candidates, Accum) ->
-    CandidateModules = get_modules(Candidates),
-    CurrentsImports = get_imports(Current),
-    CurrentsAtoms = get_atoms(Current),
-    DepModules = intersection(CurrentsImports ++ CurrentsAtoms, CandidateModules) -- Accum,
-    lists:foldl(
-        fun(DepModule, A) ->
-            case lists:member(DepModule, A) of
-                true ->
-                    A;
-                _ ->
-                    NewCandidates = remove(DepModule, Candidates),
-                    closure(get_parsed_file(DepModule, Candidates), NewCandidates, [DepModule | A])
-            end
-        end,
-        Accum,
-        DepModules
-    ).
-
-%% @private
-remove(Module, ParsedFiles) ->
-    [P || P <- ParsedFiles, Module =/= proplists:get_value(module, P)].
-
-%% @private
-get_imports(ParsedFile) ->
-    Imports = proplists:get_value(imports, proplists:get_value(chunk_refs, ParsedFile)),
-    lists:usort([M || {M, _F, _A} <- Imports]).
-
-%% @private
-get_atoms(ParsedFile) ->
-    AtomsT = [
-        Atom || {_Index, Atom} <- proplists:get_value(atoms, proplists:get_value(chunk_refs, ParsedFile))
-    ],
-    AtomsFromLiterals = get_atom_literals(proplists:get_value(uncompressed_literals, ParsedFile)),
-    lists:usort(AtomsT ++ AtomsFromLiterals).
-
-%% @private
-get_atom_literals(undefined) ->
-    [];
-get_atom_literals(UncompressedLiterals) ->
-    <<NumLiterals:32, Rest/binary>> = UncompressedLiterals,
-    get_atom_literals(NumLiterals, Rest, []).
-
-%% @private
-get_atom_literals(0, <<"">>, Accum) ->
-    Accum;
-get_atom_literals(I, Data, Accum) ->
-    <<Length:32, StartData/binary>> = Data,
-    <<EncodedLiteral:Length/binary, Rest/binary>> = StartData,
-    Literal = binary_to_term(EncodedLiteral),
-    ExtractedAtoms = extract_atoms(Literal, []),
-    get_atom_literals(I - 1, Rest, ExtractedAtoms ++ Accum).
-
-%% @private
-extract_atoms(Term, Accum) when is_atom(Term) ->
-    [Term|Accum];
-extract_atoms(Term, Accum) when is_tuple(Term) ->
-    extract_atoms(tuple_to_list(Term), Accum);
-extract_atoms(Term, Accum) when is_map(Term) ->
-    extract_atoms(maps:to_list(Term), Accum);
-extract_atoms([H|T], Accum) ->
-    HeadAtoms = extract_atoms(H, []),
-    extract_atoms(T, HeadAtoms ++ Accum);
-extract_atoms(_Term, Accum) ->
-    Accum.
-
-%% @private
-get_modules(ParsedFiles) ->
-    [get_module(ParsedFile) || ParsedFile <- ParsedFiles].
-
-%% @private
-get_module(ParsedFile) ->
-    proplists:get_value(module, ParsedFile).
-
-%% @private
-get_module_name(ParsedFile) ->
-    proplists:get_value(module_name, ParsedFile).
-
-%% @private
-get_data(ParsedFile) ->
-    proplists:get_value(data, ParsedFile).
-
-%% @private
-get_parsed_file(Module, ParsedFiles) ->
-    {value, V} = lists:search(
-        fun(ParsedFile) ->
-            proplists:get_value(module, ParsedFile) =:= Module
-        end,
-        ParsedFiles
-    ),
-    V.
-
-%% @private
-intersection(A, B) ->
-    lists:filter(
-        fun(E) ->
-            lists:member(E, B)
-        end,
-        A
-    ).
-
-%% @private
-filter_modules(Modules, ParsedFiles) ->
-    lists:filter(
-        fun(ParsedFile) ->
-            case is_beam(ParsedFile) of
-                true ->
-                    lists:member(get_module(ParsedFile), Modules);
-                _ ->
-                    true
-            end
-        end,
-        ParsedFiles
-    ).
-
-%% @private
-parse_file(beam, _ModuleName, Data) ->
-    {ok, Module, Chunks} = beam_lib:all_chunks(Data),
-    {UncompressedChunks, UncompressedLiterals} = uncompress_literals(Chunks),
-    FilteredChunks = filter_chunks(UncompressedChunks),
-    {ok, Binary} = beam_lib:build_module(FilteredChunks),
-    {ok, {Module, ChunkRefs}} = beam_lib:chunks(Data, [imports, exports, atoms]),
-    Exports = proplists:get_value(exports, ChunkRefs),
-    Flags =
-        case lists:member({start, 0}, Exports) of
-            true ->
-                ?BEAM_CODE_FLAG bor ?BEAM_START_FLAG;
-            _ ->
-                ?BEAM_CODE_FLAG
-        end,
-    [
-        [
-            {module, Module},
-            {module_name, io_lib:format("~s.beam", [atom_to_list(Module)])},
-            {flags, Flags},
-            {data, Binary},
-            {chunk_refs, ChunkRefs},
-            {uncompressed_literals, UncompressedLiterals}
-        ]
-    ];
-parse_file(avm, ModuleName, Data) ->
-    case Data of
-        <<?AVM_HEADER, AVMData/binary>> ->
-            parse_avm_data(AVMData);
-        _ ->
-            throw(io_lib:format("Invalid AVM header: ~p", [ModuleName]))
-    end;
-parse_file(normal, ModuleName, Data) ->
-    DataSize = byte_size(Data),
-    Blob = <<DataSize:32, Data/binary>>,
-    [[{module_name, ModuleName}, {flags, ?NORMAL_FILE_FLAG}, {data, Blob}]].
-
-%% @private
-reorder_start_module(StartModule, Files) ->
-    {StartProps, Other} =
-        lists:partition(
-            fun(Props) ->
-                % io:format("Props: ~w~n", [Props]),
-                case proplists:get_value(module, Props) of
-                    StartModule ->
-                        Flags = proplists:get_value(flags, Props),
-                        case is_entrypoint(Flags) of
-                            true -> true;
-                            _ -> throw({start_module_not_start_beam, StartModule})
-                        end;
-                    _ ->
-                        false
-                end
-            end,
-            Files
-        ),
-    case StartProps of
-        [] ->
-            throw({start_module_not_found, StartModule});
-        _ ->
-            StartProps ++ Other
-    end.
-
-%% @private
-parse_avm_data(AVMData) ->
-    parse_avm_data(AVMData, []).
-
-%% @private
-parse_avm_data(<<"">>, Accum) ->
-    lists:reverse(Accum);
-parse_avm_data(<<0:32/integer, _AVMRest/binary>>, Accum) ->
-    lists:reverse(Accum);
-parse_avm_data(<<Size:32/integer, AVMRest/binary>>, Accum) ->
-    SizeWithoutSizeField = Size - 4,
-    case SizeWithoutSizeField =< erlang:byte_size(AVMRest) of
-        true ->
-            <<AVMBeamData:SizeWithoutSizeField/binary, AVMNext/binary>> = AVMRest,
-            Beam = parse_beam(AVMBeamData, [], in_header, 0, []),
-            parse_avm_data(AVMNext, [Beam | Accum]);
-        _ ->
-            throw(
-                io_lib:format("Invalid AVM data size: ~p (AVMRest=~p)", [
-                    Size, erlang:byte_size(AVMRest)
-                ])
-            )
-    end.
-
-%% @private
-parse_beam(<<Flags:32, _Reserved:32, Rest/binary>>, [], in_header, Pos, Accum) ->
-    parse_beam(Rest, [], in_module_name, Pos + 8, [{flags, Flags} | Accum]);
-parse_beam(<<0:8, Rest/binary>>, Tmp, in_module_name, Pos, Accum) ->
-    ModuleName = lists:reverse(Tmp),
-    case (Pos + 1) rem 4 of
-        0 ->
-            parse_beam(Rest, Tmp, in_data, Pos, [{module_name, ModuleName} | Accum]);
-        _ ->
-            parse_beam(Rest, [], eat_padding, Pos + 1, [{module_name, ModuleName} | Accum])
-    end;
-parse_beam(<<C:8, Rest/binary>>, Tmp, in_module_name, Pos, Accum) ->
-    parse_beam(Rest, [C | Tmp], in_module_name, Pos + 1, Accum);
-parse_beam(<<0:8, Rest/binary>>, Tmp, eat_padding, Pos, Accum) ->
-    case (Pos + 1) rem 4 of
-        0 ->
-            parse_beam(Rest, Tmp, in_data, Pos, Accum);
-        _ ->
-            parse_beam(Rest, Tmp, eat_padding, Pos + 1, Accum)
-    end;
-parse_beam(Bin, Tmp, eat_padding, Pos, Accum) ->
-    parse_beam(Bin, Tmp, in_data, Pos, Accum);
-parse_beam(Data, _Tmp, in_data, _Pos, Accum) ->
-    Flags = proplists:get_value(flags, Accum),
-    case is_beam(Flags) orelse is_entrypoint(Flags) of
-        true ->
-            StrippedData = strip_padding(Data),
-            {ok, {Module, ChunkRefs}} = beam_lib:chunks(StrippedData, [imports, exports, atoms]),
-            [{module, Module}, {chunk_refs, ChunkRefs}, {data, StrippedData} | Accum];
-        _ ->
-            [{data, Data} | Accum]
-    end.
-
-strip_padding(<<0:8, Rest/binary>>) ->
-    strip_padding(Rest);
-strip_padding(Data) ->
-    Data.
-
-%% @private
-uncompress_literals(Chunks) ->
-    case proplists:get_value("LitT", Chunks) of
-        undefined ->
-            {Chunks, undefined};
-        <<_Header:4/binary, Data/binary>> ->
-            UncompressedData = zlib:uncompress(Data),
-            {
-                lists:keyreplace(
-                    "LitT",
-                    1,
-                    Chunks,
-                    {"LitU", UncompressedData}
-                ),
-                UncompressedData
-            }
-    end.
-
-%% @private
-write_packbeam(OutputFilePath, ParsedFiles) ->
-    PackedData =
-        [<<?AVM_HEADER>> | [pack_data(ParsedFile) || ParsedFile <- ParsedFiles]] ++
-            [create_header(0, 0, <<"end">>)],
-    file:write_file(OutputFilePath, PackedData).
-
-%% @private
-pack_data(ParsedFile) ->
-    ModuleName = list_to_binary(proplists:get_value(module_name, ParsedFile)),
-    Flags = proplists:get_value(flags, ParsedFile),
-    Data = proplists:get_value(data, ParsedFile),
-    HeaderSize = header_size(ModuleName),
-    HeaderPadding = create_padding(HeaderSize),
-    DataSize = byte_size(Data),
-    DataPadding = create_padding(DataSize),
-    Size = HeaderSize + byte_size(HeaderPadding) + DataSize + byte_size(DataPadding),
-    Header = create_header(Size, Flags, ModuleName),
-    <<Header/binary, HeaderPadding/binary, Data/binary, DataPadding/binary>>.
-
-%% @private
-header_size(ModuleName) ->
-    4 + 4 + 4 + byte_size(ModuleName) + 1.
-
-%% @private
-create_header(Size, Flags, ModuleName) ->
-    <<Size:32, Flags:32, 0:32, ModuleName/binary, 0:8>>.
-
-%% @private
-create_padding(Size) ->
-    case Size rem 4 of
-        0 -> <<"">>;
-        K -> list_to_binary(lists:duplicate(4 - K, 0))
-    end.
-
-%% @private
-ends_with(String, Suffix) ->
-    string:find(String, Suffix, trailing) =:= Suffix.
-
-%% @private
-filter_chunks(Chunks) ->
-    lists:filter(
-        fun({Tag, _Data}) -> lists:member(Tag, ?ALLOWED_CHUNKS) end,
-        Chunks
-    ).
-
-%% @private
-remove_names(Names, ParsedFiles) ->
-    lists:filter(
-        fun(ParsedFile) ->
-            ModuleName = proplists:get_value(module_name, ParsedFile),
-            not lists:member(ModuleName, Names)
-        end,
-        ParsedFiles
-    ).
+    io:format("WARNING.  packbeam:delete/3 is deprecated.  Use packbeam_api::delete/3 instead.~n"),
+    packbeam_api:delete(OutputPath, InputPath, Names).
 
 %%
 %% escript entrypoint
@@ -700,7 +143,7 @@ print_help() ->
 do_create(Opts, Args) ->
     validate_args(create, Opts, Args),
     [OutputFile | InputFiles] = Args,
-    ok = create(
+    ok = packbeam_api:create(
         OutputFile, InputFiles, undefined, maps:get(prune, Opts, false), maps:get(start, Opts, undefined)
     ),
     0.
@@ -709,7 +152,7 @@ do_create(Opts, Args) ->
 do_list(Opts, Args) ->
     validate_args(list, Opts, Args),
     [InputFile | _] = Args,
-    Modules = list(InputFile),
+    Modules = packbeam_api:list(InputFile),
     print_modules(Modules, maps:get(format, Opts, undefined)),
     0.
 
@@ -718,7 +161,7 @@ do_delete(Opts, Args) ->
     validate_args(delete, Opts, Args),
     [InputFile | _] = Args,
     OutputFile = maps:get(output, Opts, InputFile),
-    delete(OutputFile, InputFile, Args),
+    packbeam_api:delete(OutputFile, InputFile, Args),
     0.
 
 %% @private
@@ -775,8 +218,8 @@ print_module(ParsedFile, "default") ->
     io:format(
         "~s~s [~p]~n", [
             ModuleName,
-            case Flags band ?BEAM_START_FLAG of
-                ?BEAM_START_FLAG -> " *";
+            case packbeam_api:is_entrypoint(Flags) of
+                true -> " *";
                 _ -> ""
             end,
             byte_size(Data)
@@ -788,8 +231,8 @@ print_module(ParsedFile, "csv") ->
     io:format(
         "~s,~p,~p,~p~n", [
             ModuleName,
-            is_beam(ParsedFile),
-            is_entrypoint(ParsedFile),
+            packbeam_api:is_beam(ParsedFile),
+            packbeam_api:is_entrypoint(ParsedFile),
             byte_size(Data)
         ]
     );
@@ -847,9 +290,3 @@ parse_args(["--format", Format | T], {Opts, Args}) ->
     parse_args(T, {Opts#{format => Format}, Args});
 parse_args([H | T], {Opts, Args}) ->
     parse_args(T, {Opts, [H | Args]}).
-
-%% @private
-deduplicate([]) ->
-    [];
-deduplicate([H | T]) ->
-    [H | [X || X <- deduplicate(T), X /= H]].

--- a/test/prop_packbeam.erl
+++ b/test/prop_packbeam.erl
@@ -1,0 +1,135 @@
+%%
+%% Copyright (c) dushin.net
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+-module(prop_packbeam).
+-include_lib("proper/include/proper.hrl").
+
+-define(BUILD_DIR, "_build/").
+-define(TEST_BEAM_DIR, "_build/test/lib/packbeam/test/").
+
+
+%%
+%% Call graph for modules a-f, x
+%%
+%%
+%%          calls                   calls
+%%      a (start) ----------> b (start) ---------> e
+%%                            |
+%%                            | calls (via atomic module name)
+%%                            |
+%%                            v
+%%                            c -----------------> f
+%%                              calls (via atom inside of literal)
+%%
+%%
+%%      d  no one calls d :(
+%%
+%%
+%%   x (start) ---> a (start)
+%%
+
+%%
+%% Properties
+%%
+
+prop_simple_test() ->
+    ?FORALL(ModulePaths, module_paths(),
+        begin
+            Modules = [Module || {Module, _Path} <- ModulePaths],
+            Paths = [Path || {_Module, Path} <- ModulePaths],
+            AVMFile = dest_dir("prop_simple_test.avm"),
+            collect(
+                Modules,
+                begin
+                    ok = packbeam:create(AVMFile, Paths),
+                    ParsedFiles = packbeam:list(AVMFile),
+                    modules_and_parsed_files_are_equivalent(Modules, ParsedFiles)
+                        andalso all_beam_modules_are_properly_named(ParsedFiles)
+                        andalso maybe_contains_start_beam(Modules, a, ParsedFiles)
+                        andalso maybe_contains_start_beam(Modules, b, ParsedFiles)
+                end
+            )
+        end
+    ).
+
+modules_and_parsed_files_are_equivalent(Modules, ParsedFiles) ->
+    lists:sort(Modules) =:= lists:sort([get_module(ParsedFile) || ParsedFile <- get_beam_files(ParsedFiles)]).
+
+all_beam_modules_are_properly_named(ParsedFiles) ->
+    lists:all(
+        fun(ParsedFile) ->
+            Module = get_module(ParsedFile),
+            get_module_name(ParsedFile) =:= (atom_to_list(Module) ++ ".beam")
+        end,
+        get_beam_files(ParsedFiles)
+    ).
+
+get_beam_files(ParsedFiles) ->
+    [ParsedFile || ParsedFile <- ParsedFiles, is_beam(ParsedFile)].
+
+maybe_contains_start_beam(Modules, Module, ParsedFiles) ->
+    case lists:member(Module, Modules) of
+        true ->
+            is_start(find_parsed_file(Module, ParsedFiles));
+        _ ->
+            true %% ignore
+    end.
+
+find_parsed_file(Module, []) ->
+    {parsed_file_not_found, Module};
+find_parsed_file(Module, [ParsedFile|Rest]) ->
+    case get_module(ParsedFile) of
+        M when M =:= Module ->
+            ParsedFile;
+        _ ->
+            find_parsed_file(Module, Rest)
+    end.
+%%
+%% Helpers
+%%
+
+test_beam_path(Module) ->
+    ?TEST_BEAM_DIR ++ atom_to_list(Module) ++ ".beam".
+
+dest_dir(AVMFile) ->
+    ?BUILD_DIR ++ AVMFile.
+
+get_module(ParsedFile) ->
+    proplists:get_value(module, ParsedFile).
+
+get_module_name(ParsedFile) ->
+    proplists:get_value(module_name, ParsedFile).
+
+is_start(ParsedFile) ->
+    proplists:get_value(flags, ParsedFile) band 16#01 == 16#01.
+
+is_beam(ParsedFile) ->
+    proplists:get_value(flags, ParsedFile) band 16#02 == 16#02.
+
+%%
+%% Generators
+%%
+
+module_paths() ->
+    ?LET(
+        Modules, list(oneof([a, b, c, d, e, f])),
+        remove_duplicates([{Module, test_beam_path(Module)} || Module <- Modules])
+    ).
+
+remove_duplicates([]) ->
+    [];
+remove_duplicates([H | T]) ->
+    [H | [X || X <- remove_duplicates(T), X /= H]].

--- a/test/prop_packbeam.erl
+++ b/test/prop_packbeam.erl
@@ -54,8 +54,8 @@ prop_simple_test() ->
             collect(
                 Modules,
                 begin
-                    ok = packbeam:create(AVMFile, Paths),
-                    ParsedFiles = packbeam:list(AVMFile),
+                    ok = packbeam_api:create(AVMFile, Paths),
+                    ParsedFiles = packbeam_api:list(AVMFile),
                     modules_and_parsed_files_are_equivalent(Modules, ParsedFiles)
                         andalso all_beam_modules_are_properly_named(ParsedFiles)
                         andalso maybe_contains_start_beam(Modules, a, ParsedFiles)

--- a/test/test_packbeam.erl
+++ b/test/test_packbeam.erl
@@ -24,7 +24,7 @@
 
 packbeam_create_simple_test() ->
     AVMFile = dest_dir("packbeam_create_simple_test.avm"),
-    ?assertMatch(ok, packbeam:create(
+    ?assertMatch(ok, packbeam_api:create(
         AVMFile, [
             test_beam_path("a.beam"),
             test_beam_path("b.beam"),
@@ -34,7 +34,7 @@ packbeam_create_simple_test() ->
         ])
     ),
 
-    ParsedFiles = packbeam:list(AVMFile),
+    ParsedFiles = packbeam_api:list(AVMFile),
 
     ?assert(is_list(ParsedFiles)),
     ?assertEqual(length(ParsedFiles), 5),
@@ -75,7 +75,7 @@ packbeam_create_simple_test() ->
 packbeam_create_start_test() ->
     AVMFile = dest_dir("packbeam_create_start_test.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -88,7 +88,7 @@ packbeam_create_start_test() ->
         )
     ),
 
-    ParsedFiles = packbeam:list(AVMFile),
+    ParsedFiles = packbeam_api:list(AVMFile),
 
     ?assert(is_list(ParsedFiles)),
     ?assertEqual(length(ParsedFiles), 5),
@@ -108,7 +108,7 @@ packbeam_create_start_test() ->
 packbeam_create_prune_test() ->
     AVMFile = dest_dir("packbeam_create_prune_test.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -123,7 +123,7 @@ packbeam_create_prune_test() ->
         )
     ),
 
-    ParsedFiles = packbeam:list(AVMFile),
+    ParsedFiles = packbeam_api:list(AVMFile),
 
     ?assert(is_list(ParsedFiles)),
     ?assertEqual(length(ParsedFiles), 5),
@@ -164,7 +164,7 @@ packbeam_create_prune_test() ->
 packbeam_prune_no_start_module_test() ->
     AVMFile = dest_dir("packbeam_prune_no_start_module_test.avm"),
     ?assertException(throw, _Term,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("d.beam"),
                 test_beam_path("e.beam"),
@@ -181,7 +181,7 @@ packbeam_prune_no_start_module_test() ->
 
 packbeam_dest_fail_test() ->
     ?assertMatch({error, _},
-        packbeam:create(
+        packbeam_api:create(
             "/tmp", [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -194,7 +194,7 @@ packbeam_dest_fail_test() ->
     ),
 
     ?assertMatch({error, _},
-        packbeam:create(
+        packbeam_api:create(
             "/usr/should_not_allowed.avm", [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -207,7 +207,7 @@ packbeam_dest_fail_test() ->
     ),
 
     ?assertMatch({error, _},
-        packbeam:create(
+        packbeam_api:create(
             "/likely_doesnt_exist/should_fail.avm", [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -223,7 +223,7 @@ packbeam_dest_fail_test() ->
 
 packbeam_src_fail_test() ->
     ?assertException(throw, _Term,
-        packbeam:create(
+        packbeam_api:create(
             dest_dir("packbeam_src_fail_test.avm"), [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -240,7 +240,7 @@ packbeam_src_fail_test() ->
 packbeam_create_named_module_test() ->
     AVMFile = dest_dir("packbeam_list_test.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -251,7 +251,7 @@ packbeam_create_named_module_test() ->
         )
     ),
 
-    ParsedFiles = packbeam:list(AVMFile),
+    ParsedFiles = packbeam_api:list(AVMFile),
 
     ?assert(is_list(ParsedFiles)),
     ?assertEqual(length(ParsedFiles), 5),
@@ -266,7 +266,7 @@ packbeam_create_named_module_test() ->
 packbeam_list_test() ->
     AVMFile = dest_dir("packbeam_list_test.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -279,18 +279,18 @@ packbeam_list_test() ->
         )
     ),
 
-    packbeam:list(AVMFile),
+    packbeam_api:list(AVMFile),
 
     ?assertException(throw, _Term,
-        packbeam:list(test_beam_path("d.beam"))
+        packbeam_api:list(test_beam_path("d.beam"))
     ),
 
     ?assertException(throw, _Term,
-        packbeam:list("/usr")
+        packbeam_api:list("/usr")
     ),
 
     ?assertException(throw, _Term,
-        packbeam:list("/should_not_exist.txt")
+        packbeam_api:list("/should_not_exist.txt")
     ),
 
     ok.
@@ -298,7 +298,7 @@ packbeam_list_test() ->
 packbeam_create_dependent_avm_test() ->
     AVMFile = dest_dir("packbeam_create_dependent_avm_test.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile, [
                 test_beam_path("a.beam"),
                 test_beam_path("b.beam"),
@@ -308,11 +308,11 @@ packbeam_create_dependent_avm_test() ->
             ]
         )
     ),
-    % io:format(user, "ParsedFiles1: ~p~n", [packbeam:list(AVMFile)]),
+    % io:format(user, "ParsedFiles1: ~p~n", [packbeam_api:list(AVMFile)]),
 
     AVMFile2 = dest_dir("packbeam_create_dependent_avm_test2.avm"),
     ?assertMatch(ok,
-        packbeam:create(
+        packbeam_api:create(
             AVMFile2, [
                 test_beam_path("x.beam"),
                 AVMFile
@@ -322,7 +322,7 @@ packbeam_create_dependent_avm_test() ->
         )
     ),
 
-    ParsedFiles = packbeam:list(AVMFile2),
+    ParsedFiles = packbeam_api:list(AVMFile2),
 
     ?assert(is_list(ParsedFiles)),
     ?assertEqual(length(ParsedFiles), 5),

--- a/test/x.erl
+++ b/test/x.erl
@@ -1,0 +1,6 @@
+-module(x).
+
+-export([start/0]).
+
+start() ->
+    a:start().


### PR DESCRIPTION
This change set adds support for creating OTP applications in AVM files.

In addition, this change set includes the following:

* Added support for packing application files into AVM files
* Added PropEr test
* Enhanced the list subcommand to support different formats
* Added support for GNU-style long and short options
* Split packbeam API and escript sections into their own modules