### PR TITLE
Improve error reporting

### DIFF
--- a/src/packbeam_api.erl
+++ b/src/packbeam_api.erl
@@ -504,13 +504,18 @@ get_data(ParsedFile) ->
 
 %% @private
 get_parsed_file(Module, ParsedFiles) ->
-    {value, V} = lists:search(
+    SearchResult = lists:search(
         fun(ParsedFile) ->
             proplists:get_value(module, ParsedFile) =:= Module
         end,
         ParsedFiles
     ),
-    V.
+    case SearchResult of
+        {value, V} ->
+            V;
+        false ->
+            exit({module_not_found, Module, ParsedFiles})
+    end.
 
 %% @private
 intersection(A, B) ->


### PR DESCRIPTION
Improve error reporting (as an exit with data) when a parsed file can't be found, instead of a badmatch.