### PR TITLE
Added version sub-command and fixed line number flags.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0]
+
+- Added `version` sub-command to print version to the console
+- Added `-r`, `--remove` option and removed the `-i`, `--include` option, which was ineffective due to a bug.  See the [Updating](UPDATING.md) notes on the impact of these changes.
+
 ## [0.6.2]
 
 - Added `relx` stanzas to create a standalone release of the `packbeam` utility

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ## All rights reserved.
 ##
 
-all: compile escript edoc etest release
+all: compile escript edoc etest rel
 
 compile:
 	rebar3 compile
@@ -19,7 +19,7 @@ etest:
 	rebar3 proper --cover
 	rebar3 cover --verbose
 
-release:
+rel:
 	rebar3 release
 	rebar3 tar
 

--- a/README.md
+++ b/README.md
@@ -57,18 +57,22 @@ The general syntax of the `packbeam` command takes the form:
 On-line help is available via the `help` sub-command:
 
     shell$ packbeam help
+
+    packbeam version 0.7.0
+
     Syntax:
-    packbeam <sub-command> <options> <args>
+        packbeam <sub-command> <options> <args>
 
     The following sub-commands are supported:
 
         create <options> <output-avm-file> [<input-file>]+
             where:
             <output-avm-file> is the output AVM file,
-            [<input-file>]+ is is a list of one or more input files,
+            [<input-file>]+ is a list of one or more input files,
             and <options> are among the following:
                 [--prune|-p]           Prune dependencies
                 [--start|-s <module>]  Start module
+                [--remove_lines|-r]    Remove line number information from AVM files
 
         list <options> <avm-file>
             where:
@@ -82,17 +86,21 @@ On-line help is available via the `help` sub-command:
             [<element>]+ is a list of one or more elements to extract
                 (if empty, then extract all elements)
             and <options> are among the following:
-                [-out <output-directory>]   Output directory into which to write elements
+                [--out|-o <output-directory>]   Output directory into which to write elements
                 (if unspecified, use the current working directory)
 
         delete <options> <avm-file> [<element>]+
             where:
             <avm-file> is an AVM file,
-            [<element>]+ is is a list of one or more elements to delete,
+            [<element>]+ is a list of one or more elements to delete,
             and <options> are among the following:
-                [-out <output-avm-file>]    Output AVM file
+                [--out|-o <output-avm-file>]    Output AVM file
 
-        help  print this help
+        version
+            Print version and exit
+
+        help
+            Print this help
 
 The `packbeam` command will return an exit status of 0 on successful completion of a command.  An unspecified non-zero value is returned in the event of an error.
 
@@ -135,6 +143,12 @@ In addition, you may specify a "normal" (i.e., non-beam or non-AVM) file.  Norma
 If you specify the `--prune` (alternatively, `-p`) flag, then `packbeam` will only include beam files that are transitively dependent on the entry-point beam.  Transitive dependencies are determined by imports, as well as use of an atom in a module (e.g, as the result of a dynamic function call, based on a module name).
 
 If there is no beam file with a `start/0` entry-point defined in the list of input modules and the `--prune` flag is used, the command will fail.  You should _not_ use the `--prune` flag if you are trying to build libraries suitable for inclusion on other AtomVM applications.
+
+### Line number information
+
+By default, the `packbeam` tool will generate line number information for embedded BEAM files.  Line number information is included in Erlang stacktraces, giving developers more clues into bugs in their programs.  However, line number information does increase the size of AVM files, and in some cases can have an impact on memory in running applications.
+
+For production applications that have no need for line number information, we recommend using the `-r` (or `--remove_lines`) flags, which will strip line number information from embedded BEAM files.
 
 ## `list` sub-command
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,0 +1,11 @@
+<!---
+  Copyright 2023 Fred Dushin <fred@dushin.net>
+
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
+# AtomVM Update Instructions
+
+## 0.6.* -> 0.7.*
+
+- The default behavior of not generating line number information in BEAM files has changed.  By default, line number information will be generated in BEAM files.  You can remove line number information using from BEAM files by using the `-r` (or `--remove_lines`) flags to the `create` subcommand.  Note that in versions 0.6 of this tool, the `--include_lines` flag was ignored due to a bug in the code.

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {escript_incl_apps, [atomvm_packbeam]}.
 {escript_main_app, atomvm_packbeam}.
 {escript_name, packbeam}.
-{escript_emu_args, "%%! +sbtu +A1\n"}.
+{escript_emu_args, "%%! -escript main packbeam"}.
 
 {ex_doc, [
     {source_url, <<"https://github.com/atomvm/atomvm_packbeam">>},
@@ -30,7 +30,7 @@
 ]}.
 
 {relx, [
-    {release, {atomvm_packbeam, "0.6.2"}, [
+    {release, {atomvm_packbeam, "0.7.0"}, [
         kernel,
         stdlib,
         atomvm_packbeam

--- a/src/atomvm_packbeam.app.src
+++ b/src/atomvm_packbeam.app.src
@@ -20,7 +20,7 @@
     [
         {description,
             "An escript and library to manipulate (create, list, delete) AtomVM PackBeam files"},
-        {vsn, "0.6.2"},
+        {vsn, "0.7.0"},
         {registered, []},
         {applications, [kernel, stdlib]},
         {env, []},

--- a/src/packbeam_api.erl
+++ b/src/packbeam_api.erl
@@ -56,7 +56,7 @@
     prune => false,
     start_module => undefined,
     application_module => undefined,
-    include_lines => false
+    include_lines => true
 }).
 
 %%


### PR DESCRIPTION
This change set adds a `version` sub-command, so that users can determine the current version of the tool.  It also fixes an issue with line number flags, whereby the old `--include_lines` option was being ignored.  Since we are by default adding line number information to AVM files in the rebar3 plugin, we are changing the default behavior to include line number information by default.  Users can remove line number information using the `-r` or `--remove_lines` flags.

Miscellaneous other fixes include:
* Update version to 0.7.0
* Workaround for an issue loading the atomvm_packbeam application in a release, which prevents us from getting the proper version
* Added UPDATING.md to describe the "breaking" change in 0.7.0 (see UPDATING below)
* Fix to Makefile to build the release target properly
* Removed use of deprecated packbeam_api create call

UPDATING: The default behavior of not generating line number information in BEAM files has changed.  By default, line number information will be generated in BEAM files.  You can remove line number information using from BEAM files by using the `-r` (or `--remove_lines`) flags to the `create` subcommand.  Note that in versions 0.6 of this tool, the `--include_lines` flag was ignored due to a bug in the code.