### PR TITLE
Tighten up packbeam_api

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       matrix:
-        otp: ["22", "23", "24"]
+        otp: ["24", "25", "26"]
 
     steps:
     # Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] (unreleased)
+
+- Enhanced `packbeam_api` to make it more maintainable.
+- Changed documentation to use [`rebar3_ex_doc`](https://hexdocs.pm/rebar3_ex_doc/readme.html)
+
 ## [0.7.0]
 
 - Added `version` sub-command to print version to the console

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ## All rights reserved.
 ##
 
-all: compile escript edoc etest rel
+all: compile escript docs etest rel
 
 compile:
 	rebar3 compile
@@ -11,8 +11,8 @@ compile:
 escript:
 	rebar3 escriptize
 
-edoc:
-	rebar3 edoc
+docs:
+	rebar3 ex_doc
 
 etest:
 	rebar3 eunit --cover

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %% Copyright (c) dushin.net
 %% All rights reserved.
 %%
-{erl_opts, [no_debug_info]}.
+{erl_opts, [debug_info]}.
 {deps, []}.
 
 {escript_incl_apps, [atomvm_packbeam]}.
@@ -12,11 +12,20 @@
 
 {ex_doc, [
     {source_url, <<"https://github.com/atomvm/atomvm_packbeam">>},
-    {extras, [<<"README.md">>, <<"LICENSE">>]},
-    {main, <<"readme">>}
+    {extras, [
+        <<"README.md">>,
+        <<"CHANGELOG.md">>,
+        <<"UPDATING.md">>,
+        <<"LICENSE">>,
+        <<"CONTRIBUTING.md">>,
+        <<"CODE_OF_CONDUCT.md">>
+    ]},
+    {main, <<"README.md">>},
+    {api_reference, true},
+    {skip_undefined_reference_warnings_on, ["README.md"]}
 ]}.
-{hex, [{doc, edoc}]}.
-{plugins, [rebar3_hex, rebar3_proper]}.
+{hex, [{doc, #{provider => ex_doc}}]}.
+{plugins, [rebar3_hex, rebar3_proper, rebar3_ex_doc]}.
 
 %% Profiles
 {profiles, [

--- a/src/packbeam.erl
+++ b/src/packbeam.erl
@@ -272,13 +272,12 @@ print_modules(Modules, Format) ->
 print_module(ParsedFile, undefined) ->
     print_module(ParsedFile, "default");
 print_module(ParsedFile, "default") ->
-    ModuleName = proplists:get_value(module_name, ParsedFile),
-    Flags = proplists:get_value(flags, ParsedFile),
-    Data = proplists:get_value(data, ParsedFile),
+    Name = packbeam_api:get_element_name(ParsedFile),
+    Data = packbeam_api:get_element_data(ParsedFile),
     io:format(
         "~s~s [~p]~n", [
-            ModuleName,
-            case packbeam_api:is_entrypoint(Flags) of
+            Name,
+            case packbeam_api:is_entrypoint(ParsedFile) of
                 true -> " *";
                 _ -> ""
             end,
@@ -286,21 +285,21 @@ print_module(ParsedFile, "default") ->
         ]
     );
 print_module(ParsedFile, "csv") ->
-    ModuleName = proplists:get_value(module_name, ParsedFile),
-    Data = proplists:get_value(data, ParsedFile),
+    Name = packbeam_api:get_element_name(ParsedFile),
+    Data = packbeam_api:get_element_data(ParsedFile),
     io:format(
         "~s,~p,~p,~p~n", [
-            ModuleName,
+            Name,
             packbeam_api:is_beam(ParsedFile),
             packbeam_api:is_entrypoint(ParsedFile),
             byte_size(Data)
         ]
     );
 print_module(ParsedFile, "bare") ->
-    ModuleName = proplists:get_value(module_name, ParsedFile),
+    Name = packbeam_api:get_element_name(ParsedFile),
     io:format(
         "~s~n", [
-            ModuleName
+            Name
         ]
     );
 print_module(_ParsedFile, Format) ->

--- a/test/prop_packbeam.erl
+++ b/test/prop_packbeam.erl
@@ -108,16 +108,16 @@ dest_dir(AVMFile) ->
     ?BUILD_DIR ++ AVMFile.
 
 get_module(ParsedFile) ->
-    proplists:get_value(module, ParsedFile).
+    packbeam_api:get_element_module(ParsedFile).
 
 get_module_name(ParsedFile) ->
-    proplists:get_value(module_name, ParsedFile).
+    packbeam_api:get_element_name(ParsedFile).
 
 is_start(ParsedFile) ->
-    proplists:get_value(flags, ParsedFile) band 16#01 == 16#01.
+    packbeam_api:is_entrypoint(ParsedFile).
 
 is_beam(ParsedFile) ->
-    proplists:get_value(flags, ParsedFile) band 16#02 == 16#02.
+    packbeam_api:is_beam(ParsedFile).
 
 %%
 %% Generators

--- a/test/test_packbeam.erl
+++ b/test/test_packbeam.erl
@@ -408,19 +408,19 @@ test_beam_path(BeamFile) ->
     ?TEST_BEAM_DIR ++ BeamFile.
 
 get_module(ParsedFile) ->
-    proplists:get_value(module, ParsedFile).
+    packbeam_api:get_element_module(ParsedFile).
 
 get_module_name(ParsedFile) ->
-    proplists:get_value(module_name, ParsedFile).
+    packbeam_api:get_element_name(ParsedFile).
 
 get_exports(ParsedFile) ->
     proplists:get_value(exports, proplists:get_value(chunk_refs, ParsedFile)).
 
 is_start(ParsedFile) ->
-    proplists:get_value(flags, ParsedFile) band 16#01 == 16#01.
+    packbeam_api:is_entrypoint(ParsedFile).
 
 is_beam(ParsedFile) ->
-    proplists:get_value(flags, ParsedFile) band 16#02 == 16#02.
+    packbeam_api:is_beam(ParsedFile).
 
 parsed_file_contains_module(Module, ParsedFiles) ->
     lists:any(


### PR DESCRIPTION
This change set tightens up the packbeam API to expose just enough information about AVM files as is needed without exposing internal implementation details.

Documentation has been written for the API, and we have moved to use `ex_doc` instead of `edoc` for documentation generation.
