### PR TITLE
Fix some small bugs in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ set -e
 readonly root_dir="$(cd $(dirname $0) && pwd)"
 
 readonly nargs=$#
-if [[ ${nargs} -lt 2 ]]; then
+if [ ${nargs} -lt 2 ]; then
     echo
     echo "Syntax: $0 <prefix> <version>"
     echo "    where <prefix> is the prefix location for the install"
@@ -84,8 +84,8 @@ echo_run cp "${src_tar}" "${tmp_dir}/."
 echo_run gunzip "${tmp_dir}/atomvm_packbeam-${version}.tar.gz"
 
 readonly dest_dir="${prefix}/atomvm_packbeam"
-if [ -e "${dest_dir}" ]; then
-    echo "ERROR! It looks like ${dest_dir} already exists!"
+if [ $(${dest_dir}/bin/packbeam version) = ${version} ]; then
+    echo "ERROR! It looks like ${version} is already installed!"
     exit 1
 fi
 


### PR DESCRIPTION
Fixes bashism in the `args` test in `install.sh` that won't work with POSIX `sh`, or `bash` in `sh` mode.

Modified the pre-installation check to test if the currently installed version is the same rather than just for the presence of the `atomvm_packbeam` directory so that upgrading to other versions will be possible with future releases.

Also adds generated `doc` directory to `.gitignore`.