### PR TITLE
Fix bug in `packbeam create`

### DIFF
--- a/src/packbeam.erl
+++ b/src/packbeam.erl
@@ -184,7 +184,7 @@ do_create(Opts, Args) ->
         OutputFile, InputFiles,
         #{
             prune => maps:get(prune, Opts, false),
-            start => maps:get(start, Opts, undefined),
+            start_module => maps:get(start_module, Opts, undefined),
             include_lines => not maps:get(remove_lines, Opts, false)
         }
     ),

--- a/src/packbeam_api.erl
+++ b/src/packbeam_api.erl
@@ -120,7 +120,7 @@ create(OutputPath, InputPaths, Options) ->
         start_module := StartModule,
         application_module := ApplicationModule,
         include_lines := IncludeLines
-    } = Options,
+    } = maps:merge(?DEFAULT_OPTIONS, Options),
     ParsedFiles = parse_files(InputPaths, StartModule, IncludeLines),
     write_packbeam(
         OutputPath,


### PR DESCRIPTION
Fixes bugs in `packbeam create` command that cause the creation to fail due to the start module always ending up `undefined`, and badmatch bug if the `application_module` is not defined, due to not utilizing the default options.

The `atomvm_rebar3_plugin` has been unaffected by these bugs because it utilizes `packbeam_api` internally.