### PR TITLE
Prepare 0.7.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.4] - Unreleased
+## [0.7.4] - (2025.05.25)
+
 - Add support for OTP-28
 - Added missing licences files, and CI workflow to ensure reuse compliance
+
+>This release includes changes from 0.7.3 that were not included in the release due to a bad release tag.
 
 ## [0.7.3] (2024.06.06)
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ rel:
 	rebar3 as prod tar
 	rm -rf x
 	mkdir x
-	./install.sh x 0.7.3
+	./install.sh x 0.7.4
 	x/bin/packbeam version
 
 clean:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ On-line help is available via the `help` sub-command:
 
     shell$ packbeam help
 
-    packbeam version 0.7.2
+    packbeam version 0.7.4
 
     Syntax:
         packbeam <sub-command> <options> <args>

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
 ]}.
 
 {relx, [
-    {release, {atomvm_packbeam, "0.7.3"}, [
+    {release, {atomvm_packbeam, "0.7.4"}, [
         kernel,
         stdlib,
         atomvm_packbeam

--- a/src/atomvm_packbeam.app.src
+++ b/src/atomvm_packbeam.app.src
@@ -22,7 +22,7 @@
     [
         {description,
             "An escript and library to manipulate (create, list, delete) AtomVM PackBeam files"},
-        {vsn, "0.7.3"},
+        {vsn, "0.7.4"},
         {registered, []},
         {applications, [kernel, stdlib]},
         {env, []},


### PR DESCRIPTION
Just bumps the version so we can make sure the 0.7.3 fixes are included this time. The tag for 0.6.3 did not include aoo of the commits since the 0.6.2 release. 0.6.3 was never released on hex.pm, but we still need to bump the version to ensure no users end up using a cached version from the 0.6.3 tag on GitHub.