### PR TITLE
Add OTP-27 to CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,10 +10,10 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
-        otp: ["24", "25", "26"]
+        otp: ["25", "26", "27"]
 
     steps:
     # Setup


### PR DESCRIPTION
Bumps workflow to OTP versions 25-27.
The rebar3 bootstrap reqires at least OTP-25, so rather that checkout earier tags for each older version of OTP we will just check against the most recent 3 versions.