### PR TITLE
Tighten up workflow permissions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         otp: ["25", "26", "27"]
+    permissions:
+      contents: read
 
     steps:
     # Setup


### PR DESCRIPTION
Address workflow permission security weakness by restriction workflow to only the necessary "read" permission.