### PR TITLE
Update CI build and test to include OTP-28

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     strategy:
       matrix:
-        otp: ["25", "26", "27"]
+        otp: ["25", "26", "27", "28"]
 
     steps:
     # Setup


### PR DESCRIPTION
Add OTP-28 to the build-and-test.yaml workflow matrix.