### PR TITLE
Support OTP-28 uncompressed literals

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     strategy:
       matrix:
-        otp: ["25", "26", "27"]
+        otp: ["25", "26", "27", "28"]
 
     steps:
     # Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.4] - Unreleased
-
+- Add support for OTP-28
 
 ## [0.7.3] (2024.06.06)
 


### PR DESCRIPTION
Handle new OTP-28 uncompressed literals when running on OTP 28 and later, continues to support zlib compression for literals with earlier OTP versions.

Closes #30