### PR TITLE
Fix workflow for OTP 25

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,6 +14,15 @@ jobs:
     strategy:
       matrix:
         otp: ["25", "26", "27", "28"]
+        include:
+          - otp: "25"
+            make_jobs: "compile escript etest rel"
+          - otp: "26"
+            make_jobs: "all"
+          - otp: "27"
+            make_jobs: "all"
+          - otp: "28"
+            make_jobs: "all"
     permissions:
       contents: read
 
@@ -49,4 +58,4 @@ jobs:
 
     # Build
     - name: "Make"
-      run: PATH="/tmp/rebar3:${PATH}" make
+      run: PATH="/tmp/rebar3:${PATH}" make ${{ matrix.make_jobs }}


### PR DESCRIPTION
Fix broken OTP 25 test by excluding building the documentation which uses ex_doc, which is only available for OTP 26 and later.