### PR TITLE
Suppress warning about missing sasl

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 %%
 %% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, nowarn_sasl]}.
 {deps, []}.
 
 {escript_incl_apps, [atomvm_packbeam]}.


### PR DESCRIPTION
Add `nowarn_sasl` to the rebar.config erl_opts to suppress the warning when assembling the release:
```
*WARNING* Missing application sasl. Can not upgrade with this release
```

This escript tool does not need sasl since we are not doing OTP application style upgrades. We can safely ignore this warning, and it may be confusing or misleading to users.

See issue #34.