### PR TITLE
Add missing permissions to workflows

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -23,7 +23,11 @@ jobs:
   format-check:
     runs-on: ubuntu-24.04
     container: erlang:28
+    permissions:
+      contents: read
+
     steps:
+
     - name: "Install deps"
       run: |
         apt install -y git
@@ -35,7 +39,8 @@ jobs:
         cd erlfmt
         rebar3 as release escriptize
 
-    - uses: actions/checkout@v4
+    - name: "Checkout code"
+      uses: actions/checkout@v5
 
     - name: "Check formatting with erlfmt"
       run: |

--- a/.github/workflows/reuse-lint.yaml
+++ b/.github/workflows/reuse-lint.yaml
@@ -13,7 +13,10 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542


### PR DESCRIPTION
Adds missing permissions to check-formatting and reuse workflows. For more security these workflows only need read permission.

Bump `checkout` action version to v5 for both workflows.