### PR TITLE
Prepare 0.7.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5] - (2025.08.18)
+
+- Fix unnecessary warning about missing `sasl`
+- Corrected install documentation
+
 ## [0.7.4] - (2025.05.25)
 
 - Add support for OTP-28
-- Added missing licences files, and CI workflow to ensure reuse compliance
+- Added missing license files, and CI workflow to ensure reuse compliance
 
 >This release includes changes from 0.7.3 that were not included in the release due to a bad release tag.
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ rel:
 	rebar3 as prod tar
 	rm -rf x
 	mkdir x
-	./install.sh x 0.7.4
+	./install.sh x 0.7.5
 	x/bin/packbeam version
 
 clean:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This tool roughly approximates the functionality of the AtomVM `PackBEAM` utilit
 
 The `packbeam` tool may be used on its own as a stand-alone command-line utility.  More typically, it is used internally as part of the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin) [`rebar3`](https://rebar3.org) plugin.
 
+[Releases](https://hex.pm/packages/atomvm_packbeam) and
+[accompanying documentation](https://hexdocs.pm/atomvm_packbeam/readme.html) are available on
+[hex.pm](https://hex.pm). The documentation for the current master branch is always available from
+the [`atomvm_packbeam` GitHub pages](https://atomvm.github.io/atomvm_packbeam/readme.html).
+
 ## Prerequisites
 
 Building `packbeam` requires a version of Erlang/OTP compatible with [AtomVM](https://github.com/atomvm/AtomVM), as well as a local installation of [`rebar3`](https://rebar3.org).  Optionally, any recent version of `make` may be used to simplify builds.  Consult the [AtomVM Documentation](https://doc.atomvm.org/latest/) for information about supported OTP versions.
@@ -29,7 +34,7 @@ To build a release, run the following commands:
 These commands will create an Erlang tar archive containing a versioned release of the `atomvm_packbeam` tool, e.g.,
 
     ...
-    ===> Tarball successfully created: _build/prod/rel/atomvm_packbeam/atomvm_packbeam-0.6.2.tar.gz
+    ===> Tarball successfully created: _build/prod/rel/atomvm_packbeam/atomvm_packbeam-0.7.5.tar.gz
 
 in your local working directory.
 
@@ -37,8 +42,8 @@ in your local working directory.
 
 You can use the `install.sh` script to install the `atomvm_packbeam` utility into a location on your local machine.  You will need to specify the prefix location into which you want to install the utility, together with it's current version.
 
-    shell$ ./install.sh /opt/atomvm_packbeam 0.7.4
-    atomvm_packbeam version 0.7.4 installed in /opt/atomvm_packbeam.
+    shell$ ./install.sh /opt/atomvm_packbeam 0.7.5
+    atomvm_packbeam version 0.7.5 installed in /opt/atomvm_packbeam.
 
 > Note.  Some prefix locations may require `root` permissions to write files to.
 
@@ -64,7 +69,7 @@ On-line help is available via the `help` sub-command:
 
     shell$ packbeam help
 
-    packbeam version 0.7.4
+    packbeam version 0.7.5
 
     Syntax:
         packbeam <sub-command> <options> <args>

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
 ]}.
 
 {relx, [
-    {release, {atomvm_packbeam, "0.7.4"}, [
+    {release, {atomvm_packbeam, "0.7.5"}, [
         kernel,
         stdlib,
         atomvm_packbeam

--- a/src/atomvm_packbeam.app.src
+++ b/src/atomvm_packbeam.app.src
@@ -22,7 +22,7 @@
     [
         {description,
             "An escript and library to manipulate (create, list, delete) AtomVM PackBeam files"},
-        {vsn, "0.7.4"},
+        {vsn, "0.7.5"},
         {registered, []},
         {applications, [kernel, stdlib]},
         {env, []},


### PR DESCRIPTION
Bumps the release version to 0.7.5 in source and documentation files.
Adds changelog section for release 0.7.5.
Minor touch up to readme.